### PR TITLE
Update Snakefile

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -208,8 +208,13 @@ rule MergeAdapters:
     output: "MergeAdapters/merged.fasta"
     shell: "cat {input} > {output}"
 
+rule subset_Adapters:
+    input: "MergeAdapters/merged.fasta",
+    output: "MergeAdapters/merged.subset.fasta"
+    shell: "awk '/^>/ {{P=index($0,""No Hit"")==0}} {{if(P) print}} ' {input} > {output}"
+
 rule CutAdapt:
-    input: "MergeAdapters/merged.fasta", "PreFilterReads/{name}.fastq"
+    input: "MergeAdapters/merged.subset.fasta", "PreFilterReads/{name}.fastq"
     output: "CutAdaptMerge/{name}.fastq"
     run:
         with open(str(input[0])) as f:

--- a/Snakefile
+++ b/Snakefile
@@ -211,7 +211,10 @@ rule MergeAdapters:
 rule subset_Adapters:
     input: "MergeAdapters/merged.fasta",
     output: "MergeAdapters/merged.subset.fasta"
-    shell: "awk '/^>/ {{P=index($0,""No Hit"")==0}} {{if(P) print}} ' {input} > {output}"
+    shell:
+        """
+	awk '/^>/ {{P=index($0,"No Hit")==0}} {{if(P) print}} ' {input} > {output}
+        """
 
 rule CutAdapt:
     input: "MergeAdapters/merged.subset.fasta", "PreFilterReads/{name}.fastq"


### PR DESCRIPTION
As it is right now we basically filter the fastq files against everything which ends up in the "merged.fasta"file after extracting info from fastqc. This could incorporate overrepresented sequences from the species analysed (e.g. ribosomal origin) and artefacts such as adapters from Illumina. We should focus on hits against Illumina adapter sequences. The rule to add here will extract the fasta entries that show hits against adapter sequences