### PR TITLE
Display tool versions

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -103,8 +103,6 @@ OUTPUT_FILES.extend(expand("Summary/MappingStats/{name}.txt", name=INPUT_FILES, 
 OUTPUT_FILES.append(result('all_counts.csv'))
 OUTPUT_FILES.append("Summary/software_versions.txt")
 
-
-
 rule all:
     input: OUTPUT_FILES
 

--- a/Snakefile
+++ b/Snakefile
@@ -216,7 +216,7 @@ rule subset_Adapters:
     output: "MergeAdapters/merged.subset.fasta"
     shell:
         """
-    awk '/^>/ {{P=index($0,"No Hit")==0}} {{if(P) print}} ' {input} > {output}
+        awk '/^>/ {{P=index($0,"No Hit")==0}} {{if(P) print}} ' {input} > {output}
         """
 
 rule CutAdapt:
@@ -296,11 +296,13 @@ rule NumreadsOrig:
     input: "fastq/{name}.fastq"
     output: "Summary/NumReads/Original/{name}.txt"
     shell: '''dc -e "$(wc -l {input} | cut -f1 -d' ') 4 / p" > {output}'''
+        
 """
 Rule to get software versions of used programs in workflow. Rule either calls program with --version flag if possible, or runs
 it without parameters displaying output row containing version information with unix tail command.
 It then redirects it to Summary/software_versions.txt 
 """
+
 rule SoftwareVersions:
     input: result("all_counts.csv")
     output: "Summary/software_versions.txt"

--- a/Snakefile
+++ b/Snakefile
@@ -101,6 +101,9 @@ OUTPUT_FILES.extend(expand("TopHat2/{name}/accepted_hits.bai", name=INPUT_FILES,
 OUTPUT_FILES.extend(expand("Summary/MappingStats/{name}.txt", name=INPUT_FILES, result=RESULT))
 #OUTPUT_FILES.append("checksums.ok")
 OUTPUT_FILES.append(result('all_counts.csv'))
+OUTPUT_FILES.append("Summary/software_versions.txt")
+
+
 
 rule all:
     input: OUTPUT_FILES
@@ -213,7 +216,7 @@ rule subset_Adapters:
     output: "MergeAdapters/merged.subset.fasta"
     shell:
         """
-	awk '/^>/ {{P=index($0,"No Hit")==0}} {{if(P) print}} ' {input} > {output}
+    awk '/^>/ {{P=index($0,"No Hit")==0}} {{if(P) print}} ' {input} > {output}
         """
 
 rule CutAdapt:
@@ -293,3 +296,19 @@ rule NumreadsOrig:
     input: "fastq/{name}.fastq"
     output: "Summary/NumReads/Original/{name}.txt"
     shell: '''dc -e "$(wc -l {input} | cut -f1 -d' ') 4 / p" > {output}'''
+"""
+Rule to get software versions of used programs in workflow. Rule either calls program with --version flag if possible, or runs
+it without parameters displaying output row containing version information with unix tail command.
+It then redirects it to Summary/software_versions.txt
+"""
+rule SoftwareVersions:
+    input: result("all_counts.csv")
+    output: "Summary/software_versions.txt"
+    run:
+        shell("anaconda --version > Summary/software_versions.txt")
+        shell("conda --version >> Summary/software_versions.txt")
+        shell("fastqc --version >> Summary/software_versions.txt")
+        shell("htseq-count -h | tail -1 >> Summary/software_versions.txt")
+        shell("bowtie2 --version | head -1 >> Summary/software_versions.txt")
+        shell("tophat2 --version >> Summary/software_versions.txt")
+        shell("samtools --version | head -2 >> Summary/software_versions.txt")

--- a/Snakefile
+++ b/Snakefile
@@ -216,7 +216,7 @@ rule subset_Adapters:
     output: "MergeAdapters/merged.subset.fasta"
     shell:
         """
-        awk '/^>/ {{P=index($0,"No Hit")==0}} {{if(P) print}} ' {input} > {output}
+       awk '/^>/ {{P=index($0,"No Hit")==0}} {{if(P) print}} ' {input} > {output}
         """
 
 rule CutAdapt:

--- a/Snakefile
+++ b/Snakefile
@@ -299,7 +299,7 @@ rule NumreadsOrig:
 """
 Rule to get software versions of used programs in workflow. Rule either calls program with --version flag if possible, or runs
 it without parameters displaying output row containing version information with unix tail command.
-It then redirects it to Summary/software_versions.txt
+It then redirects it to Summary/software_versions.txt 
 """
 rule SoftwareVersions:
     input: result("all_counts.csv")


### PR DESCRIPTION
Added a rule to generate a text file containing the program versions of the used tools.
The text file is called software_versions.txt and located in the var/Summary folder.